### PR TITLE
feat: track interactive AI usage via UserPromptSubmit heartbeats

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -9,9 +9,37 @@ const logger_1 = require("./logger");
 const utils_1 = require("./utils");
 const options = new options_1.Options();
 const deps = new dependencies_1.Dependencies(options, logger_1.logger);
+function sendProjectHeartbeat(projectFolder, claudeVersion) {
+    const wakatime_cli = deps.getCliLocation();
+    const args = [
+        '--entity',
+        projectFolder,
+        '--entity-type',
+        'app',
+        '--category',
+        'ai coding',
+        '--plugin',
+        `claude/${claudeVersion} claude-code-wakatime/${version_1.VERSION}`,
+        '--project-folder',
+        projectFolder,
+    ];
+    logger_1.logger.debug(`Sending project heartbeat: ${(0, utils_1.formatArguments)(wakatime_cli, args)}`);
+    const execOptions = (0, utils_1.buildOptions)();
+    (0, child_process_1.execFile)(wakatime_cli, args, execOptions, (error, stdout, stderr) => {
+        const output = stdout.toString().trim() + stderr.toString().trim();
+        if (output)
+            logger_1.logger.error(output);
+        if (error)
+            logger_1.logger.error(error.toString());
+    });
+}
 function sendHeartbeat(inp) {
     const projectFolder = inp?.cwd;
     const { entities, claudeVersion } = (0, utils_1.getEntityFiles)(inp);
+    if (inp?.hook_event_name === 'UserPromptSubmit' && projectFolder) {
+        sendProjectHeartbeat(projectFolder, claudeVersion);
+        return true;
+    }
     if (entities.size === 0)
         return false;
     const wakatime_cli = deps.getCliLocation();


### PR DESCRIPTION
Send project-level heartbeats when user submits prompts, not just when files are edited. This captures time spent on AI-assisted work like debugging, planning, and code review discussions.

This fixes #10 