### PR TITLE
Fix typo in --sync-ai-disabled flag name

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -41501,7 +41501,7 @@ async function sendHeartbeat(inp) {
   for (const [entityFile, entityData] of entities.entries()) {
     logger.debug(`Entity: ${entityFile}`);
     const args = [
-      "--sync-ai-disable",
+      "--sync-ai-disabled",
       "--entity",
       entityFile,
       "--entity-type",

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ async function sendHeartbeat(inp: Input | undefined): Promise<boolean> {
   for (const [entityFile, entityData] of entities.entries()) {
     logger.debug(`Entity: ${entityFile}`);
     const args: string[] = [
-      '--sync-ai-disable',
+      '--sync-ai-disabled',
       '--entity',
       entityFile,
       '--entity-type',


### PR DESCRIPTION
## Summary
- Fix `--sync-ai-disable` → `--sync-ai-disabled` flag passed to wakatime-cli
- The missing `d` caused every heartbeat to fail with `unknown flag: --sync-ai-disable` since v3.1.6

## Test plan
- [x] Verified the correct flag name from `wakatime-cli --help` output (`--sync-ai-disabled`)
- [x] Ran the plugin locally with debug logging and confirmed heartbeats are sent successfully with no errors